### PR TITLE
Add 360 panorama viewer with gyroscope support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,228 @@
+<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>360° Панорама</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        background: #000;
+        color: #f0f0f0;
+      }
 
+      #viewer {
+        position: fixed;
+        inset: 0;
+      }
+
+      #ui {
+        position: fixed;
+        inset: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        max-width: min(100%, 320px);
+        pointer-events: none;
+      }
+
+      #status {
+        padding: 12px 16px;
+        border-radius: 12px;
+        background: rgba(0, 0, 0, 0.55);
+        backdrop-filter: blur(4px);
+        line-height: 1.4;
+        pointer-events: auto;
+      }
+
+      #gyroButton {
+        align-self: flex-start;
+        padding: 12px 20px;
+        border: none;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.15);
+        color: inherit;
+        font-size: 16px;
+        cursor: pointer;
+        pointer-events: auto;
+        transition: background 0.2s ease;
+      }
+
+      #gyroButton:hover,
+      #gyroButton:focus-visible {
+        background: rgba(255, 255, 255, 0.35);
+        outline: none;
+      }
+
+      #gyroButton.hidden {
+        display: none;
+      }
+
+      @media (max-width: 600px) {
+        #ui {
+          inset: auto 16px 16px 16px;
+        }
+
+        #status {
+          font-size: 14px;
+        }
+
+        #gyroButton {
+          font-size: 15px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="viewer"></div>
+    <div id="ui">
+      <button id="gyroButton" class="hidden">Включить гироскоп</button>
+      <div id="status">
+        Перемещайте камеру с помощью мыши или касаний. На мобильных устройствах доступно управление
+        гироскопом.
+      </div>
+    </div>
+
+    <script src="three.min.js"></script>
+    <script src="OrbitControls.js"></script>
+    <script src="DeviceOrientationControls.js"></script>
+    <script>
+      (function () {
+        const PANORAMA_PATH = 'panorama_4096x2048.jpg';
+        const container = document.getElementById('viewer');
+        const statusLabel = document.getElementById('status');
+        const gyroButton = document.getElementById('gyroButton');
+
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        container.appendChild(renderer.domElement);
+
+        const scene = new THREE.Scene();
+        const camera = new THREE.PerspectiveCamera(
+          75,
+          window.innerWidth / window.innerHeight,
+          0.1,
+          1100
+        );
+        camera.position.set(0, 0, 0.1);
+
+        const sphereGeometry = new THREE.SphereBufferGeometry(500, 60, 40);
+        sphereGeometry.scale(-1, 1, 1);
+
+        const sphereMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff });
+        const sphere = new THREE.Mesh(sphereGeometry, sphereMaterial);
+        scene.add(sphere);
+
+        const orbitControls = new THREE.OrbitControls(camera, renderer.domElement);
+        orbitControls.enableZoom = false;
+        orbitControls.enablePan = false;
+        orbitControls.rotateSpeed = 0.4;
+        orbitControls.target.set(0, 0, 0);
+
+        let deviceControls = null;
+        let usingDeviceControls = false;
+
+        const textureLoader = new THREE.TextureLoader();
+        textureLoader.load(
+          PANORAMA_PATH,
+          (texture) => {
+            sphereMaterial.map = texture;
+            sphereMaterial.needsUpdate = true;
+            statusLabel.textContent =
+              'Панорама загружена. Перемещайте устройство или используйте жесты для обзора.';
+            maybeEnableGyro();
+          },
+          undefined,
+          (error) => {
+            console.error('Не удалось загрузить панораму', error);
+            statusLabel.textContent = 'Не удалось загрузить изображение панорамы.';
+          }
+        );
+
+        function animate() {
+          requestAnimationFrame(animate);
+          if (usingDeviceControls && deviceControls) {
+            deviceControls.update();
+          } else {
+            orbitControls.update();
+          }
+          renderer.render(scene, camera);
+        }
+
+        animate();
+
+        function onWindowResize() {
+          camera.aspect = window.innerWidth / window.innerHeight;
+          camera.updateProjectionMatrix();
+          renderer.setSize(window.innerWidth, window.innerHeight);
+        }
+
+        window.addEventListener('resize', onWindowResize);
+
+        function maybeEnableGyro() {
+          const hasDeviceOrientation = 'DeviceOrientationEvent' in window;
+          if (!hasDeviceOrientation) {
+            statusLabel.textContent += ' Гироскоп не поддерживается этим устройством.';
+            return;
+          }
+
+          const activateControls = () => {
+            if (usingDeviceControls) {
+              return;
+            }
+
+            if (!deviceControls) {
+              deviceControls = new THREE.DeviceOrientationControls(camera);
+            }
+
+            deviceControls.connect();
+            usingDeviceControls = true;
+            orbitControls.enabled = false;
+            gyroButton.classList.add('hidden');
+            statusLabel.textContent = 'Управляйте обзором, поворачивая устройство.';
+          };
+
+          const requestPermissionIfNeeded = () => {
+            if (
+              typeof DeviceOrientationEvent !== 'undefined' &&
+              typeof DeviceOrientationEvent.requestPermission === 'function'
+            ) {
+              DeviceOrientationEvent.requestPermission()
+                .then((response) => {
+                  if (response === 'granted') {
+                    activateControls();
+                  } else {
+                    statusLabel.textContent = 'Доступ к гироскопу отклонён.';
+                  }
+                })
+                .catch((err) => {
+                  console.warn('Не удалось получить доступ к гироскопу', err);
+                  statusLabel.textContent = 'Не удалось получить доступ к гироскопу.';
+                });
+            } else {
+              activateControls();
+            }
+          };
+
+          const needsSecureContext =
+            typeof DeviceMotionEvent !== 'undefined' &&
+            typeof DeviceMotionEvent.requestPermission === 'function';
+
+          if (needsSecureContext && !window.isSecureContext) {
+            statusLabel.textContent =
+              'Для активации гироскопа откройте страницу по HTTPS или добавьте её в "Домой".';
+            return;
+          }
+
+          gyroButton.classList.remove('hidden');
+          gyroButton.addEventListener('click', requestPermissionIfNeeded, { once: true });
+        }
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- build a Three.js-based 360° panorama viewer around the provided equirectangular image
- add orbit controls for desktop interaction and a UI for enabling gyroscope control on mobile
- handle texture loading feedback, resize events, and device orientation permission requirements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0537690008324b3c832d41b4043da